### PR TITLE
Feature/carlsamu/account page

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -7,8 +7,8 @@ export default function TabLayout() {
             <Tabs.Screen
                 name="index"
                 options={{
-                    headerShown: false,
                     title: 'Home',
+                    headerShown: false,
                     tabBarIcon: ({ color, focused }) => (
                         <Ionicons name={focused ? 'home-sharp' : 'home-outline'} color={color} size={24} />
                     ),
@@ -36,6 +36,7 @@ export default function TabLayout() {
                 name="account"
                 options={{
                     title: 'Account',
+                    headerShown: false,
                     tabBarIcon: ({ color, focused }) => (
                         <Ionicons name={focused ? 'person-sharp' : 'person-outline'} color={color} size={24} />
                     ),

--- a/app/(tabs)/account.tsx
+++ b/app/(tabs)/account.tsx
@@ -1,11 +1,172 @@
-import { Text, View } from 'react-native';
-import commonStyles from '@shared/styles'
+import { FlatList, Image, ScrollView, StyleSheet, Text, Touchable, TouchableOpacity, View } from 'react-native';
+import { sellers } from '../shared/mockSellers';
+import fallbackImage from '../../assets/images/fallback.png';
+import { products } from '../shared/mockProducts';
+import ProductCard from '../ProductCard';
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import { Ionicons } from '@expo/vector-icons';
+
+// Placeholder testing functionality for mock seller
+const seller = sellers[0];
 
 export default function AccountScreen() {
+    const router = useRouter();
+
+    const [showPassword, setShowPassword] = useState(false);
+
+    const maskedPassword = '•'.repeat(8);
+
+    const handleShowPass = () => {
+        setShowPassword(prev => !prev);
+    }
+
+    // redirects to Product Details view
+    const handleProductClick = (item: any) => {
+        router.push(`/product/${item.id}`)
+    };
+
     return (
-        <View style={commonStyles.container}>
-            <Text style={commonStyles.text}>insert Account content here</Text>
+      <View style={styles.container}>
+        <View style={styles.header}>
+            <Text style={styles.headerTitle}>Settings</Text>
+            <Image
+              alt=""
+              source={{ uri: seller.image }}
+              style={styles.image}
+              defaultSource={fallbackImage}
+              accessibilityLabel={`Image of ${seller.name}`}
+            />
         </View>
+
+        <View style={styles.accountSummary}>
+          <Text style={styles.accountTitle}>Account Information</Text>
+          <View style={styles.accountRow}>
+            <Text style={styles.accountLabel}>Name</Text>
+            <View style={styles.accountValueGroup}>
+              <Text style={styles.accountValue}>{seller.name}</Text>
+              <TouchableOpacity onPress={() => router.push(`/edit?field=name&value=${encodeURIComponent(seller.name)}`)}>
+              <Ionicons name="chevron-forward" size={16} color="black"/>
+            </TouchableOpacity>
+            </View>
+
+          </View>
+          <View style={styles.accountRow}>
+            <Text style={styles.accountLabel}>Email Address</Text>
+            <View style={styles.accountValueGroup}>
+              <Text style={styles.accountValue}>{seller.email}</Text>
+              <TouchableOpacity onPress={() => router.push(`/edit?field=email&value=${encodeURIComponent(seller.email)}`)}>
+                <Ionicons name="chevron-forward" size={16} color="black"/>
+              </TouchableOpacity>
+            </View>
+
+
+          </View>
+          <View style={styles.accountRow}>
+            <Text style={styles.accountLabel}>Password</Text>
+            <View style={styles.accountValueGroup}>
+              <TouchableOpacity onPress={handleShowPass}>
+                <Text style={styles.accountValue}>
+                {showPassword ? seller.passwordHash : maskedPassword}
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity onPress={() => router.push(`/edit?field=password&value=${encodeURIComponent(seller.passwordHash)}`)}>
+                <Ionicons name="chevron-forward" size={16} color="black"/>
+              </TouchableOpacity>
+            </View>
+
+          </View>
+        </View>
+
+        <View style={styles.listingsSummary}>
+          <Text style={styles.listingsTitle}>My Listings</Text>
+
+          <FlatList
+            data={products}
+            keyExtractor={(item) => item.id.toString()}
+            numColumns={2}
+            renderItem={({ item }) => (
+              <ProductCard
+                product={item}
+                onPress={() => handleProductClick(item)}
+              />
+            )}
+            contentContainerStyle={styles.listingsContainer}
+            showsVerticalScrollIndicator={false}
+          />
+        </View>
+      </View>
     );
 }
 
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  image: {
+    width: 80,
+    height: 80,
+    borderRadius: 9999,
+  },
+  accountSummary: {
+    marginTop: 12,
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    shadowColor: 'rgba(0, 0, 0, 0.5)',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 1.41,
+  },
+  accountTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  accountRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    height: 44,
+  },
+  accountLabel: {
+    fontSize: 16,
+  },
+  accountValueGroup: {
+    flexDirection: 'row',
+    gap: 5,
+  },
+  accountValue: {
+    fontSize: 16,
+    color: 'grey',
+  },
+  listingsSummary: {
+    flex: 1,
+    marginTop: 12,
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    shadowColor: 'rgba(0, 0, 0, 0.5)',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 1.41,
+  },
+  listingsContainer: {
+    paddingBottom: 24,
+  },
+  listingsTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+})

--- a/app/(tabs)/account.tsx
+++ b/app/(tabs)/account.tsx
@@ -65,10 +65,12 @@ export default function AccountScreen() {
           <View style={styles.accountRow}>
             <Text style={styles.accountLabel}>Password</Text>
             <View style={styles.accountValueGroup}>
-              <TouchableOpacity onPress={handleShowPass}>
-                <Text style={styles.accountValue}>
+              <Text style={styles.accountValue}>
                 {showPassword ? seller.passwordHash : maskedPassword}
-                </Text>
+              </Text>
+
+              <TouchableOpacity onPress={handleShowPass}>
+                <Ionicons name={showPassword ? "eye" : "eye-off"} size={16} color="black"/>
               </TouchableOpacity>
 
               <TouchableOpacity onPress={() => router.push(`/edit?field=password&value=${encodeURIComponent(seller.passwordHash)}`)}>
@@ -144,7 +146,7 @@ const styles = StyleSheet.create({
   },
   accountValueGroup: {
     flexDirection: 'row',
-    gap: 5,
+    gap: 10,
   },
   accountValue: {
     fontSize: 16,

--- a/app/(tabs)/account.tsx
+++ b/app/(tabs)/account.tsx
@@ -1,4 +1,4 @@
-import { FlatList, Image, ScrollView, StyleSheet, Text, Touchable, TouchableOpacity, View } from 'react-native';
+import { FlatList, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { sellers } from '../shared/mockSellers';
 import fallbackImage from '../../assets/images/fallback.png';
 import { products } from '../shared/mockProducts';
@@ -6,13 +6,14 @@ import ProductCard from '../ProductCard';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { Ionicons } from '@expo/vector-icons';
+import { useEditAccount } from '../shared/EditAccountContext';
 
-// Placeholder testing functionality for mock seller
+// Placeholder testing functionality
 const seller = sellers[0];
 
 export default function AccountScreen() {
     const router = useRouter();
-
+    const { setFieldValue } = useEditAccount();
     const [showPassword, setShowPassword] = useState(false);
 
     const maskedPassword = '•'.repeat(8);
@@ -25,6 +26,13 @@ export default function AccountScreen() {
     const handleProductClick = (item: any) => {
         router.push(`/product/${item.id}`)
     };
+
+    const handleLogout = () => {
+      console.log("handleLogout() called")
+    }
+
+    const sellerListingCount = products.filter(
+      product => product.seller === seller.username).length;
 
     return (
       <View style={styles.container}>
@@ -45,9 +53,12 @@ export default function AccountScreen() {
             <Text style={styles.accountLabel}>Name</Text>
             <View style={styles.accountValueGroup}>
               <Text style={styles.accountValue}>{seller.name}</Text>
-              <TouchableOpacity onPress={() => router.push(`/edit?field=name&value=${encodeURIComponent(seller.name)}`)}>
-              <Ionicons name="chevron-forward" size={16} color="black"/>
-            </TouchableOpacity>
+              <TouchableOpacity onPress={() => {
+                setFieldValue('name', seller.name);
+                router.push('/editAccount');
+              }}>
+                <Ionicons name="chevron-forward" size={16} color="black"/>
+              </TouchableOpacity>
             </View>
 
           </View>
@@ -55,7 +66,10 @@ export default function AccountScreen() {
             <Text style={styles.accountLabel}>Email Address</Text>
             <View style={styles.accountValueGroup}>
               <Text style={styles.accountValue}>{seller.email}</Text>
-              <TouchableOpacity onPress={() => router.push(`/edit?field=email&value=${encodeURIComponent(seller.email)}`)}>
+              <TouchableOpacity onPress={() => {
+                setFieldValue('email', seller.email);
+                router.push('/editAccount');
+              }}>
                 <Ionicons name="chevron-forward" size={16} color="black"/>
               </TouchableOpacity>
             </View>
@@ -73,19 +87,21 @@ export default function AccountScreen() {
                 <Ionicons name={showPassword ? "eye" : "eye-off"} size={16} color="black"/>
               </TouchableOpacity>
 
-              <TouchableOpacity onPress={() => router.push(`/edit?field=password&value=${encodeURIComponent(seller.passwordHash)}`)}>
+              <TouchableOpacity onPress={() => {
+                setFieldValue('password', seller.passwordHash);
+                router.push('/editAccount')
+              }}>
                 <Ionicons name="chevron-forward" size={16} color="black"/>
               </TouchableOpacity>
             </View>
-
           </View>
         </View>
 
         <View style={styles.listingsSummary}>
-          <Text style={styles.listingsTitle}>My Listings</Text>
+          <Text style={styles.listingsTitle}>My Listings ({sellerListingCount})</Text>
 
           <FlatList
-            data={products}
+            data={products.filter(product => product.seller === seller.username)}
             keyExtractor={(item) => item.id.toString()}
             numColumns={2}
             renderItem={({ item }) => (
@@ -98,6 +114,12 @@ export default function AccountScreen() {
             showsVerticalScrollIndicator={false}
           />
         </View>
+
+        <View style={styles.logoutContainer}>
+          <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+            <Text style={styles.logoutText}>Log Out</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     );
 }
@@ -109,12 +131,12 @@ const styles = StyleSheet.create({
   },
   header: {
     alignItems: 'center',
-    marginBottom: 12,
+    marginBottom: 3,
   },
   headerTitle: {
     fontSize: 20,
     fontWeight: '600',
-    marginBottom: 12,
+    marginBottom: 3,
   },
   image: {
     width: 80,
@@ -122,7 +144,7 @@ const styles = StyleSheet.create({
     borderRadius: 9999,
   },
   accountSummary: {
-    marginTop: 12,
+    marginTop: 6,
     padding: 16,
     backgroundColor: '#fff',
     borderRadius: 12,
@@ -134,12 +156,12 @@ const styles = StyleSheet.create({
   accountTitle: {
     fontSize: 18,
     fontWeight: '600',
-    marginBottom: 16,
+    marginBottom: 8,
   },
   accountRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    height: 44,
+    height: 36,
   },
   accountLabel: {
     fontSize: 16,
@@ -164,11 +186,21 @@ const styles = StyleSheet.create({
     shadowRadius: 1.41,
   },
   listingsContainer: {
-    paddingBottom: 24,
+    paddingBottom: 12,
   },
   listingsTitle: {
     fontSize: 18,
     fontWeight: '600',
-    marginBottom: 16,
+    marginBottom: 8,
   },
+  logoutContainer: {
+    marginTop: 6,
+    alignItems: 'center',
+  },
+  logoutButton: {
+    backgroundColor: '',
+  },
+  logoutText: {
+    color: 'darkred',
+  }
 })

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,17 +1,16 @@
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { AuthProvider } from '../app/contexts/AuthContext'
+import { EditAccountProvider } from './shared/EditAccountContext';
 
 export default function RootLayout() {
   return (
-    <AuthProvider>
+    <EditAccountProvider>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
         <StatusBar style="light" />
-        <Stack.Screen name="edit" options={{ title: "" }} />
-        <Stack.Screen name="login" options={{ headerShown: false }} />
+        <Stack.Screen name="editAccount" options={{ title: "" }} />
       </Stack>
-    </AuthProvider>
+    </EditAccountProvider>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,17 @@
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { AuthProvider } from '../app/contexts/AuthContext'
 
 export default function RootLayout() {
   return (
-    <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen name="+not-found" />
-      <StatusBar style="light" />
-      <Stack.Screen name="edit" options={{ title: "" }} />
-    </Stack>
+    <AuthProvider>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="+not-found" />
+        <StatusBar style="light" />
+        <Stack.Screen name="edit" options={{ title: "" }} />
+        <Stack.Screen name="login" options={{ headerShown: false }} />
+      </Stack>
+    </AuthProvider>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ export default function RootLayout() {
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="+not-found" />
       <StatusBar style="light" />
+      <Stack.Screen name="edit" options={{ title: "" }} />
     </Stack>
   );
 }

--- a/app/authApi.ts
+++ b/app/authApi.ts
@@ -1,0 +1,15 @@
+import { sellers } from '../app/shared/mockSellers';
+import { User } from '../app/shared/interfaces';
+
+export async function mockLogin(email: string, password: string): Promise<User> {
+    const fakeHash = `hashed_${password}`;
+    const user = sellers.find((u) => u.email === email && u.passwordHash === fakeHash);
+
+    if (!user) {
+        throw new Error("Invalid email or password");
+    }
+
+    await new Promise((res) => setTimeout(res, 500));
+
+    return user;
+}

--- a/app/contexts/AuthContext.jsx
+++ b/app/contexts/AuthContext.jsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState } from 'react';
+import { mockLogin } from '../authApi'
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+    const [user, setUser] = useState(null);
+
+    async function login(email, password) {
+        try {
+            const loggedInUser = await mockLogin(email, password);
+            setUser(loggedInUser);
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    async function signup(email, password) {
+
+    }
+
+    async function logout() {
+
+    }
+
+    return (
+        <AuthContext.Provider value={{ user, login, signup, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/app/edit.tsx
+++ b/app/edit.tsx
@@ -1,0 +1,106 @@
+import { useLocalSearchParams } from 'expo-router';
+import { StyleSheet, SafeAreaView, View, Text, TextInput, TouchableOpacity } from "react-native";
+import { useState } from 'react';
+import { useRouter } from 'expo-router';
+
+export default function EditScreen() {
+    const { field, value } = useLocalSearchParams<{ field?: string; value?: string }>();
+    const router = useRouter();
+    const [inputValue, setInputValue] = useState(value || '');
+
+    const label = {
+        name: 'Name',
+        email: 'Email Address',
+        password: 'Password',
+    }[field ?? ''] || 'Field';
+
+    const handleSave = () => {
+        console.log(`Saving ${field}:`, inputValue);
+        router.back();
+    };
+
+    return (
+        <SafeAreaView>
+            <View style={styles.container}>
+                <View style={styles.header}>
+                    <Text style={styles.title}>Edit {label}</Text>
+                </View>
+
+                <View style={styles.form}>
+                    <View style={styles.inputGroup}>
+                        <Text style={styles.inputLabel}>{label}</Text>
+                        <TextInput
+                            secureTextEntry={field === 'password'}
+                            keyboardType={field === 'email' ? 'email-address' : 'default'}
+                            style={styles.inputControl}
+                            value={inputValue}
+                            placeholder={`Enter new ${label.toLowerCase()}`}
+                            clearButtonMode="while-editing"
+                            onChangeText={setInputValue}
+                        />
+                    </View>
+                </View>
+
+                <TouchableOpacity
+                    style={styles.formAction}
+                    onPress={handleSave}
+                >
+                    <View style={styles.btn}>
+                        <Text style={styles.btnTxt}>Save</Text>
+                    </View>
+                </TouchableOpacity>
+              </View>
+        </SafeAreaView>
+    );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+  },
+  header: {
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 6,
+  },
+  form: {
+    flex: 1,
+    marginBottom: 24,
+  },
+  inputGroup: {
+    marginBottom: 12,
+  },
+  inputLabel: {
+    fontSize: 15,
+    fontWeight: '400',
+    marginBottom: 8,
+    color: 'grey',
+  },
+  inputControl: {
+    height: 44,
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+  },
+  formAction: {
+    marginTop: 4,
+    marginBottom: 12,
+  },
+  btn: {
+    backgroundColor: 'purple',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'purple',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+  },
+  btnTxt: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#fff'
+  },
+})

--- a/app/editAccount.tsx
+++ b/app/editAccount.tsx
@@ -1,0 +1,114 @@
+import { StyleSheet, SafeAreaView, View, Text, TextInput, TouchableOpacity } from "react-native";
+import { useEffect, useState } from 'react';
+import { useRouter } from "expo-router";
+import { useEditAccount } from "./shared/EditAccountContext";
+
+export default function EditAccount() {
+    const router = useRouter();
+    const { field, value, clearFieldValue } = useEditAccount();
+    const [inputValue, setInputValue] = useState(value || '');
+
+    useEffect(() => () => clearFieldValue(), []);
+    useEffect(() => {   // update data with input value
+      if (value !== null) setInputValue(value);
+    }, [value]);
+
+    if (!field || value === null) {
+      return (
+        <View style={styles.container}>
+          <Text>No field selected to edit.</Text>
+        </View>
+      );
+    }
+
+    const handleSave = () => {
+      console.log("handleSave() called");
+      clearFieldValue();
+      router.back();
+    };
+
+    const label = field.charAt(0).toUpperCase() + field.slice(1);
+
+    return (
+        <SafeAreaView>
+          <View style={styles.container}>
+            <View style={styles.header}>
+              <Text style={styles.title}>Edit {label}</Text>
+            </View>
+
+            <View style={styles.form}>
+              <View style={styles.inputGroup}>
+                <Text style={styles.inputLabel}>{label}</Text>
+                <TextInput
+                  secureTextEntry={field === 'password'}
+                  keyboardType={field === 'email' ? 'email-address' : 'default'}
+                  style={styles.inputControl}
+                  value={inputValue}
+                  placeholder={`Enter new ${label.toLowerCase()}`}
+                  clearButtonMode="while-editing"
+                  onChangeText={setInputValue}
+                  accessibilityLabel={`Input for ${label}`}
+                />
+              </View>
+            </View>
+
+            <TouchableOpacity style={styles.formAction} onPress={handleSave}>
+              <View style={styles.btn}>
+                <Text style={styles.btnTxt}>Save</Text>
+              </View>
+            </TouchableOpacity>
+          </View>
+        </SafeAreaView>
+    );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+  },
+  header: {
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 6,
+  },
+  form: {
+    flex: 1,
+    marginBottom: 24,
+  },
+  inputGroup: {
+    marginBottom: 12,
+  },
+  inputLabel: {
+    fontSize: 15,
+    fontWeight: '400',
+    marginBottom: 8,
+    color: 'grey',
+  },
+  inputControl: {
+    height: 44,
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+  },
+  formAction: {
+    marginTop: 4,
+    marginBottom: 12,
+  },
+  btn: {
+    backgroundColor: 'purple',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'purple',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+  },
+  btnTxt: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#fff'
+  },
+})

--- a/app/shared/EditAccountContext.tsx
+++ b/app/shared/EditAccountContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+type EditAccountContextType = {
+    field: string | null;
+    value: string | null;
+    setFieldValue: (field: string, value: string) => void;
+    clearFieldValue: () => void;
+};
+
+const EditAccountContext = createContext<EditAccountContextType | null>(null);
+
+type EditAccountProviderProps = {
+    children: ReactNode;
+};
+
+export const EditAccountProvider = ({ children }: EditAccountProviderProps) => {
+    const [field, setField] = useState<string | null>(null);
+    const [value, setValue] = useState<string | null>(null);
+
+    const setFieldValue = (f: string, v: string) => {
+        setField(f);
+        setValue(v);
+    };
+
+    const clearFieldValue = () => {
+        setField(null);
+        setValue(null);
+    }
+
+    return (
+        <EditAccountContext.Provider value={{ field, value, setFieldValue, clearFieldValue }}>
+            {children}
+        </EditAccountContext.Provider>
+    );
+};
+
+export const useEditAccount = () => {
+    const context = useContext(EditAccountContext);
+    if (!context) throw new Error('useEditAccount must be used within an EditAccountProvider');
+    return context;
+};

--- a/app/shared/interfaces.ts
+++ b/app/shared/interfaces.ts
@@ -21,14 +21,14 @@ export interface ProductListing {
 
 export interface User {
   username: string;
-  email: string | null;
+  email: string;
   passwordHash: string;
   createdDatetime: string;
   updatedDatetime: string;
 
   // new attributes
   image: string;
-  name?: string;
+  name: string;
   rating?: number;
   location?: string;
 }

--- a/app/shared/mockProducts.ts
+++ b/app/shared/mockProducts.ts
@@ -170,4 +170,21 @@ export const products: ProductListing[] = [
     image:
       "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTo9AUql84MSPVXggXT_jDp0aEObY2RUEOYXQ&s",
   },
+  {
+    id: 11,
+    activeStatus: "active",
+    title: "Power Drill",
+    description: "Dewalt 20V cordless drill with charger and two batteries.",
+    seller: "justin123",
+    price: 65.0,
+    createdDatetime: "2025-04-25T10:30:00Z",
+    updatedDatetime: "2025-04-25T12:15:00Z",
+    expirationDatetime: null,
+    category: "Tools & Home Improvement",
+    condition: "Like New",
+    location: "Austin, TX",
+    isSold: false,
+    image:
+      "https://images.unsplash.com/photo-1632095710940-ad578e8cbe6b?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  },
 ];


### PR DESCRIPTION
Implemented the UI layout for the Account and Edit Account pages. The handleLogout() and handleSave() functions currently have placeholder functionality. I'm currently working on getting the CRUD functionality implemented.

**Account Page:**
- Displayed account information, including profile picture, full name, email, and password.
- Implemented Show/Hide password functionality.
- Displayed product listings under account information, showing each user’s individual listings.

**Edit Account Page:**
- Account information is displayed using Auth Context.
- Added placeholder functionality for saving account information edits.
- Implemented a back button to navigates the user back to the account page.

**Minor Edits:**
- interfaces.ts: Fixed an issue with User interface’s email and name fields.
- mockProducts.ts: Added an additional product listing to user one to demonstrate the Account product listings feature.
- _layout.tsx: Wrapped Stack with EditAccountProvider for context management.
<img src="https://github.com/user-attachments/assets/2d0fce36-4459-44de-88f0-2438fda508aa" alt="localhost_8081_account(iPhone 6_7_8)" width="400">
<img src="https://github.com/user-attachments/assets/03ace358-04e3-45c1-bb6e-12362865cd0a"
alt="localhost_8081_account(iPhone 6_7_8) (1)" width="400">



